### PR TITLE
bugfix: walletNameToAddressAndProfilePicture resolves .backpack owner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -405,7 +405,7 @@ export const walletNameToAddressAndProfilePicture = async (
   if (walletName.endsWith(".glow")) {
     walletAddressAndProfilePicture = await dotGlowToWallet(walletName);
   }
-  if (walletName.endsWith(".backpack") && jwt) {
+  if (walletName.endsWith(".backpack")) {
     walletAddressAndProfilePicture = await dotBackpackToWallet(walletName, jwt);
   }
   if (walletName.startsWith("@")) {


### PR DESCRIPTION
bugfix: walletNameToAddressAndProfilePicture resolves .backpack owner even if there is no jwt